### PR TITLE
remove unnecessary crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacher",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Cryptographic component",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,6 @@
   },
   "homepage": "https://github.com/FreeAllMedia/hacher",
   "dependencies": {
-    "crypto": "0.0.3",
     "hashids": "1.0.2",
     "jsonwebtoken": "^5.0.4",
     "uuid-1345": "^0.99.6"


### PR DESCRIPTION
See https://medium.com/@rmehlinger/crypto-collision-f41c206de27b. This package has no license and no tests, and masks a built in NodeJS library. Thankfully, Node does not allow its crypto package to be overwritten by this thing, so requiring it doesn't actually do anything.